### PR TITLE
Add GitHub Actions workflow for PDF generation testing

### DIFF
--- a/.github/workflows/_pdf-job.yml
+++ b/.github/workflows/_pdf-job.yml
@@ -1,0 +1,40 @@
+name: PDF Job (reusable)
+
+on:
+  workflow_call:
+    inputs:
+      upload_artifact:
+        required: true
+        type: boolean
+
+jobs:
+  build-pdf:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run PDF generation script
+        run: |
+          python src/impression_cartes.py -o cartes-impression.pdf
+
+      - name: Check PDF output
+        run: |
+          test -f cartes-impression.pdf && echo "PDF généré avec succès."
+
+      - name: Upload PDF as artifact
+        if: ${{ inputs.upload_artifact }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: cartes-impression-pdf
+          path: cartes-impression.pdf

--- a/.github/workflows/release-impression-cartes.yml
+++ b/.github/workflows/release-impression-cartes.yml
@@ -1,0 +1,11 @@
+name: Release impression_cartes.py
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  release-pdf-generation:
+    uses: ./.github/workflows/_pdf-job.yml
+    with:
+      upload_artifact: true

--- a/.github/workflows/test-impression-cartes.yml
+++ b/.github/workflows/test-impression-cartes.yml
@@ -18,31 +18,6 @@ on:
 
 jobs:
   test-pdf-generation:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: '3.11'
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install -r requirements.txt
-
-      - name: Run PDF generation script
-        run: |
-          python src/impression_cartes.py -o cartes-impression.pdf
-
-      - name: Check PDF output
-        run: |
-          test -f cartes-impression.pdf && echo "PDF généré avec succès."
-
-      - name: Upload PDF as artifact (optionnel)
-        uses: actions/upload-artifact@v4
-        with:
-          name: cartes-impression-pdf
-          path: cartes-impression.pdf
+    uses: ./.github/workflows/_pdf-job.yml
+    with:
+      upload_artifact: false


### PR DESCRIPTION
This pull request introduces GitHub Actions workflows to automate testing and releasing for the `impression_cartes.py` PDF generation script. The main addition is a reusable workflow for building the PDF, which is then used by both the test and release workflows.

Workflow automation:

* Added a reusable workflow (`.github/workflows/_pdf-job.yml`) that checks out the code, sets up Python, installs dependencies, runs the PDF generation script, checks for successful PDF creation, and optionally uploads the PDF as an artifact.

Test and release pipelines:

* Created a test workflow (`.github/workflows/test-impression-cartes.yml`) that triggers on changes to key files and runs the PDF build workflow without uploading the artifact.
* Created a release workflow (`.github/workflows/release-impression-cartes.yml`) that triggers on published releases and runs the PDF build workflow with artifact upload enabled.