### PR TITLE
Fix recto-verso layout

### DIFF
--- a/specs-impression.md
+++ b/specs-impression.md
@@ -13,13 +13,22 @@
 
 ## Disposition des pages
 - Les pages impaires affichent les rectos des cartes, les pages paires affichent les versos correspondants.
-- L'ordre d'enchaînement est strict : 
-	- page 1 : rectos cartes 1, 2, 3, 4
-	- page 2 : versos cartes 1, 2, 3, 4
-	- page 3 : rectos cartes 5, 6, 7, 8
-	- page 4 : versos cartes 5, 6, 7, 8
-	- etc.
-- Les cartes sont positionnées pour permettre une impression recto-verso (retournement petit côté), afin que recto et verso coïncident lors du découpage manuel.
+
+### Disposition recto-verso (pour retournement petit côté)
+
+Pour chaque groupe de 4 cartes :
+
+- **Page impaire (recto)**
+	- carte 1 recto | carte 2 recto
+	- carte 3 recto | carte 4 recto
+
+- **Page paire (verso)**
+	- carte 2 recto | carte 1 recto
+	- carte 4 recto | carte 3 recto
+
+Ensuite, on passe au groupe de 4 cartes suivant (cartes 5 à 8, etc.).
+
+Ce placement permet, lors de l'impression recto-verso avec retournement sur le petit côté, d'obtenir un alignement parfait des cartes recto et verso après découpe.
 
 ## Types de cartes
 

--- a/src/impression_cartes.py
+++ b/src/impression_cartes.py
@@ -174,10 +174,10 @@ def generate_pdf(output_path):
     c = canvas.Canvas(output_path, pagesize=landscape(A4))
     # Pages recto/verso enchaînées strictement
     for i in range(0, len(cartes), 4):
-        # Rectos
+        # Rectos (ordre naturel)
         for idx in range(4):
             if i + idx >= len(cartes):
-                break
+                continue
             carte = cartes[i + idx]
             col = idx % 2
             row = idx // 2
@@ -186,13 +186,15 @@ def generate_pdf(output_path):
             draw_recto(c, carte, x, y)
         draw_guides(c)
         c.showPage()
-        # Versos
-        for idx in range(4):
+        # Versos (inversion des colonnes)
+        # Mapping: [0,1,2,3] -> [1,0,3,2]
+        verso_order = [1,0,3,2]
+        for pos, idx in enumerate(verso_order):
             if i + idx >= len(cartes):
-                break
+                continue
             carte = cartes[i + idx]
-            col = idx % 2
-            row = idx // 2
+            col = pos % 2
+            row = pos // 2
             x = col * CARD_WIDTH
             y = PAGE_HEIGHT - (row + 1) * CARD_HEIGHT
             draw_verso(c, carte, x, y)


### PR DESCRIPTION
This pull request updates both the documentation and the PDF generation logic to clarify and correctly implement the layout of cards for double-sided printing (with short-edge flipping). The main change is to ensure that the verso (back) sides of the cards are positioned so that, after printing and cutting, the fronts and backs align perfectly.

**Documentation update:**

* Improved the explanation in `specs-impression.md` to describe the recto-verso card arrangement for short-edge duplex printing, including a clear description and example of the card order on each page.

**Code logic update:**

* In `src/impression_cartes.py`, updated the PDF generation logic so that:
  - The recto (front) sides are placed in natural order.
  - The verso (back) sides use a specific column inversion order (`[1,0,3,2]`) to ensure correct alignment after printing and cutting. [[1]](diffhunk://#diff-5c1607093b2adda4e168352a64dda8690adb398d600882a063aeb83ef87436cfL177-R180) [[2]](diffhunk://#diff-5c1607093b2adda4e168352a64dda8690adb398d600882a063aeb83ef87436cfL189-R197)